### PR TITLE
slidesToSlide-To accept 0 as truthy value

### DIFF
--- a/coverage/lcov-report/src/utils/common.ts.html
+++ b/coverage/lcov-report/src/utils/common.ts.html
@@ -573,7 +573,7 @@ function getSlidesToSlide(
 ): number {
   const { domLoaded, slidesToShow, containerWidth, itemWidth } = state;
   const { deviceType, responsive } = props;
-  let slidesToScroll = props.slidesToSlide || <span class="branch-1 cbranch-no" title="branch not covered" >1;</span>
+  let slidesToScroll = props.slidesToSlide !== undefined ? props.slidesToSlide : <span class="branch-1 cbranch-no" title="branch not covered" >1;</span>;
   const domFullyLoaded = Boolean(
     domLoaded &amp;&amp; <span class="branch-1 cbranch-no" title="branch not covered" >slidesToShow </span>&amp;&amp; <span class="branch-2 cbranch-no" title="branch not covered" >containerWidth </span>&amp;&amp; <span class="branch-3 cbranch-no" title="branch not covered" >itemWidth</span>
   );

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -151,7 +151,7 @@ function getSlidesToSlide(
 ): number {
   const { domLoaded, slidesToShow, containerWidth, itemWidth } = state;
   const { deviceType, responsive } = props;
-  let slidesToScroll = props.slidesToSlide || 1;
+  let slidesToScroll = props.slidesToSlide !== undefined ? props.slidesToSlide : 1;
   const domFullyLoaded = Boolean(
     domLoaded && slidesToShow && containerWidth && itemWidth
   );


### PR DESCRIPTION
We are using react-multi-carousel for our app and we are hit with below limitation / issue.

Given: Some of the slides in our carousel have more than 1 buttons on it.
When: those slides are focused, 1st button get focus.
Then: i press right
Expected: Focus should move to next button on the same slide.
Actual: Focus moving to next slide

I found that if slidesToSlide can be dynamically set to 0 when such slides are focused, i will be able to block the slide transition until the focus is on last button.

In this PR, i have made slidesToSlide to be defaulted to 1, only of responsive.slidesToSlide is undefined, so that 0 is accepted as a truthy value.